### PR TITLE
fixed building upstream cluster state 

### DIFF
--- a/charts/ali-operator-crd/templates/crds.yaml
+++ b/charts/ali-operator-crd/templates/crds.yaml
@@ -52,6 +52,7 @@ spec:
                 nullable: true
                 type: string
               endpointPublicAccess:
+                nullable: true
                 type: boolean
               imported:
                 type: boolean
@@ -142,7 +143,7 @@ spec:
                       type: string
                     systemDiskSize:
                       type: integer
-                    vSwitchIds:
+                    vswitchIds:
                       items:
                         nullable: true
                         type: string
@@ -173,6 +174,7 @@ spec:
                 nullable: true
                 type: string
               snatEntry:
+                nullable: true
                 type: boolean
               vpcId:
                 nullable: true

--- a/pkg/alibaba/cluster.go
+++ b/pkg/alibaba/cluster.go
@@ -68,9 +68,9 @@ func newClusterCreateRequest(configSpec *aliv1.AliClusterConfigSpec) *cs.CreateC
 	req.ContainerCidr = tea.String(configSpec.ContainerCIDR)
 	req.ServiceCidr = tea.String(configSpec.ServiceCIDR)
 	req.NodeCidrMask = tea.String(strconv.Itoa(configSpec.NodeCIDRMask))
-	req.SnatEntry = tea.Bool(configSpec.SNATEntry)
+	req.SnatEntry = configSpec.SNATEntry
 	req.ProxyMode = tea.String(configSpec.ProxyMode)
-	req.EndpointPublicAccess = tea.Bool(configSpec.EndpointPublicAccess)
+	req.EndpointPublicAccess = configSpec.EndpointPublicAccess
 	req.SecurityGroupId = tea.String(configSpec.SecurityGroupID)
 	req.Addons = GetAddons(configSpec)
 	req.PodVswitchIds = tea.StringSlice(configSpec.PodVswitchIDs)

--- a/pkg/alibaba/nodepool.go
+++ b/pkg/alibaba/nodepool.go
@@ -58,6 +58,7 @@ func ToNodePoolConfig(nodePools []*cs.DescribeClusterNodePoolsResponseBodyNodepo
 			np.Period = tea.Int64Value(nodePool.ScalingGroup.Period)
 			np.PeriodUnit = tea.StringValue(nodePool.ScalingGroup.PeriodUnit)
 			np.ImageType = tea.StringValue(nodePool.ScalingGroup.ImageType)
+			np.ImageID = tea.StringValue(nodePool.ScalingGroup.ImageId)
 			np.SystemDiskCategory = tea.StringValue(nodePool.ScalingGroup.SystemDiskCategory)
 			np.SystemDiskSize = tea.Int64Value(nodePool.ScalingGroup.SystemDiskSize)
 			np.VSwitchIDs = tea.StringSliceValue(nodePool.ScalingGroup.VswitchIds)

--- a/pkg/apis/ali.cattle.io/v1/types.go
+++ b/pkg/apis/ali.cattle.io/v1/types.go
@@ -67,11 +67,11 @@ type AliClusterConfigSpec struct {
 	PodVswitchIDs []string `json:"podVswitchIds,omitempty" norman:"noupdate"`
 	// SNATEntry specifies whether to configure SNAT rules for the VPC in which your cluster is deployed.
 	// if false nodes and applications in the cluster cannot access the Internet.
-	SNATEntry bool `json:"snatEntry"`
+	SNATEntry *bool `json:"snatEntry,omitempty"`
 	// ProxyMode the kube-proxy mode
 	ProxyMode string `json:"proxyMode,omitempty"`
 	// EndpointPublicAccess specifies whether to enable Internet access for the cluster.
-	EndpointPublicAccess bool `json:"endpointPublicAccess"`
+	EndpointPublicAccess *bool `json:"endpointPublicAccess,omitempty"`
 	// SecurityGroupID specifies security group for cluster nodes.
 	SecurityGroupID string `json:"securityGroupId,omitempty" norman:"noupdate"`
 	// ResourceGroupID the Id of the resource group to which the cluster belongs.
@@ -133,7 +133,7 @@ type AliNodePool struct {
 	// ImageType is the type of the OS image
 	ImageType string `json:"imageType,omitempty"`
 	// VSwitchIDs are the VSwitchIds for the nodes.
-	VSwitchIDs []string `json:"vSwitchIds,omitempty"`
+	VSwitchIDs []string `json:"vswitchIds,omitempty"`
 	// SystemDiskCategory is the category of the system disk.
 	SystemDiskCategory string `json:"systemDiskCategory,omitempty"`
 	// SystemDiskSize is the size of the system disk

--- a/pkg/apis/ali.cattle.io/v1/zz_generated_deepcopy.go
+++ b/pkg/apis/ali.cattle.io/v1/zz_generated_deepcopy.go
@@ -115,6 +115,16 @@ func (in *AliClusterConfigSpec) DeepCopyInto(out *AliClusterConfigSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.SNATEntry != nil {
+		in, out := &in.SNATEntry, &out.SNATEntry
+		*out = new(bool)
+		**out = **in
+	}
+	if in.EndpointPublicAccess != nil {
+		in, out := &in.EndpointPublicAccess, &out.EndpointPublicAccess
+		*out = new(bool)
+		**out = **in
+	}
 	if in.ZoneIDs != nil {
 		in, out := &in.ZoneIDs, &out.ZoneIDs
 		*out = make([]string, len(*in))


### PR DESCRIPTION
https://github.com/rancher/ali-operator/issues/42
1. fix missing imageid in alistatus upstream spec of management cluster.
2. made endpublicaccess and snat entry as pointers so that those are in sync when importing the cluster.
3. initialised povswitchids, zoneId and snatentry for imported cluster correctly.
4. fix jsonkey for vswitch id field for nodepool
 