### PR TITLE
[release-v2.13] added rancher version and kube version annotation to crd chart

### DIFF
--- a/charts/ali-operator-crd/Chart.yaml
+++ b/charts/ali-operator-crd/Chart.yaml
@@ -10,3 +10,5 @@ annotations:
   catalog.cattle.io/release-name: rancher-ali-operator-crd
   catalog.cattle.io/os: linux
   catalog.cattle.io/permits-os: linux,windows
+  catalog.cattle.io/kube-version: ">= 1.32.0-0 < 1.35.0-0"
+  catalog.cattle.io/rancher-version: ">= 2.13.0-0 < 2.14.0-0"


### PR DESCRIPTION
backport for https://github.com/rancher/ali-operator/pull/74