### PR TITLE
Add support for image pull secrets

### DIFF
--- a/charts/ali-operator/templates/_helpers.tpl
+++ b/charts/ali-operator/templates/_helpers.tpl
@@ -22,3 +22,26 @@ add below linux tolerations to workloads could be scheduled to those linux nodes
 {{- define "linux-node-selector" -}}
 kubernetes.io/os: linux
 {{- end -}}
+
+{{/*
+Renders imagePullSecrets, accepting either object references ({ name: <secret> })
+or plain strings.
+*/}}
+{{- define "rancher-ali-operator.imagePullSecrets" -}}
+{{- $pullSecrets := list -}}
+{{- range .Values.global.cattle.imagePullSecrets -}}
+  {{- if kindIs "map" . -}}
+    {{- if .name -}}
+      {{- $pullSecrets = append $pullSecrets .name -}}
+    {{- end -}}
+  {{- else if not (empty .) -}}
+    {{- $pullSecrets = append $pullSecrets . -}}
+  {{- end -}}
+{{- end -}}
+{{- if not (empty $pullSecrets) -}}
+imagePullSecrets:
+  {{- range $pullSecrets | uniq }}
+  - name: {{ . }}
+  {{- end }}
+{{- end -}}
+{{- end -}}

--- a/charts/ali-operator/templates/deployment.yaml
+++ b/charts/ali-operator/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{.Values.priorityClassName}}"
       {{- end }}
+      {{- include "rancher-ali-operator.imagePullSecrets" . | nindent 6 }}
       securityContext:
         fsGroup: 1007
         runAsUser: 1007

--- a/charts/ali-operator/values.yaml
+++ b/charts/ali-operator/values.yaml
@@ -1,6 +1,7 @@
 global:
   cattle:
     systemDefaultRegistry: ""
+    imagePullSecrets: []
 
 aliOperator:
   image:


### PR DESCRIPTION
This PR adds support for image pull secrets within the ali-operator chart. There aren't any chart unit tests that I could find, but I verified that these changes produce a valid manifest using `helm template`

Related issue: https://github.com/rancher/rancher/issues/54806

<details>
<summary>
Helm Template Output
</summary>

`helm template ./ --set 'global.cattle.imagePullSecrets[0]=regcred'`

```yaml
# Source: rancher-ali-operator/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  namespace: cattle-system
  name: ali-operator
---
# Source: rancher-ali-operator/templates/clusterrole.yaml
kind: ClusterRole
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: ali-operator
  namespace: cattle-system
rules:
  - apiGroups: ['']
    resources: ['secrets']
    verbs: ['get', 'list', 'create', 'watch', 'update']
  - apiGroups: ['ali.cattle.io']
    resources: ['aliclusterconfigs']
    verbs: ['get', 'list', 'update', 'watch']
  - apiGroups: ['ali.cattle.io']
    resources: ['aliclusterconfigs/status']
    verbs: ['update']
---
# Source: rancher-ali-operator/templates/clusterrolebinding.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name:  ali-operator
  namespace: cattle-system
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: ali-operator
subjects:
- kind: ServiceAccount
  name: ali-operator
  namespace: cattle-system
---
# Source: rancher-ali-operator/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: ali-config-operator
  namespace: cattle-system
spec:
  replicas: 1
  selector:
    matchLabels:
      ke.cattle.io/operator: ali
  template:
    metadata:
      labels:
        ke.cattle.io/operator: ali
    spec:
      nodeSelector: 
        kubernetes.io/os: linux
      tolerations: 
        - key: "cattle.io/os"
          value: "linux"
          effect: "NoSchedule"
          operator: "Equal"
      serviceAccountName: ali-operator
      imagePullSecrets:
        - name: regcred
      securityContext:
        fsGroup: 1007
        runAsUser: 1007
      containers:
      - name: ali-operator
        image: 'rancher/ali-operator:v0.0.0'
        imagePullPolicy: IfNotPresent
        env:
        - name: HTTP_PROXY
          value: 
        - name: HTTPS_PROXY
          value: 
        - name: NO_PROXY
          value: 
        securityContext:
          allowPrivilegeEscalation: false
          readOnlyRootFilesystem: true
          privileged: false
          capabilities:
            drop:
            - ALL
```

</details>